### PR TITLE
Discard empty blocks at parse time

### DIFF
--- a/src/parse.lisp
+++ b/src/parse.lisp
@@ -346,7 +346,9 @@
           expr)))
 
   (as :toplevel (loop :until (token-type-p token :eof)
-                      :collect (statement))))
+                   :for stmt = (statement)
+                   :unless (and (eq (car stmt) :block)
+                                (not (cadr stmt))) :collect stmt)))
 
 (defun parse-js-string (string &optional strict-semicolons)
   (with-input-from-string (in string)


### PR DESCRIPTION
Just a quick hack to discard empty blocks generated by superfluous semicolons from the AST.  I got into the habit of using too many semicolons, i.e:

```
function foo() {
  something()
};
```

Here the last semicolon is not required but generates an empty :block in the AST.  This patch gets around it.
