### PR TITLE
Don't try lock the Lisp REPL if parse-js or read-js-number receive a NIL value

### DIFF
--- a/src/parse.lisp
+++ b/src/parse.lisp
@@ -23,6 +23,7 @@
   `(let ((*label-scope* (cons (cons ,type ,label) *label-scope*))) ,@body))
 
 (defun parse-js (input &key strict-semicolons (ecma-version 3) reserved-words)
+  (check-type input (or string stream))
   (check-type ecma-version (member 3 5))
   (let ((*ecma-version* ecma-version)
         (*check-for-reserved-words* reserved-words)

--- a/src/tokenize.lisp
+++ b/src/tokenize.lisp
@@ -63,6 +63,7 @@
 (defparameter *ecma-version* 3)
 
 (defun read-js-number (stream &key junk-allowed)
+  (check-type stream stream)
   (flet ((peek-1 () (peek-char nil stream nil nil))
          (next-1 () (read-char stream nil nil)))
     (read-js-number-1 #'peek-1 #'next-1 :junk-allowed junk-allowed)))


### PR DESCRIPTION
This pull request adds calls to `check-type` that ensure that the functions `parse-js` and `read-js-number` throw an error if they receive the NIL value.

Fixes #7 
